### PR TITLE
Refactored DocumentsDirectoryURL

### DIFF
--- a/Source/CoreDataModel.swift
+++ b/Source/CoreDataModel.swift
@@ -117,7 +117,7 @@ public struct CoreDataModel: CustomStringConvertible, Equatable {
 
     - returns: A new `CoreDataModel` instance.
     */
-    public init(name: String, bundle: NSBundle = .mainBundle(), storeType: StoreType = .SQLite(DocumentsDirectoryURL())) {
+    public init(name: String, bundle: NSBundle = .mainBundle(), storeType: StoreType = .SQLite(DefaultDirectoryURL())) {
         self.name = name
         self.bundle = bundle
         self.storeType = storeType
@@ -154,15 +154,21 @@ public struct CoreDataModel: CustomStringConvertible, Equatable {
 
 // MARK: Internal
 
-internal func DocumentsDirectoryURL() -> NSURL {
+internal func DefaultDirectoryURL() -> NSURL {
     do {
+        #if os(tvOS)
+            let searchPathDirectory = NSSearchPathDirectory.CachesDirectory
+        #else
+            let searchPathDirectory = NSSearchPathDirectory.DocumentDirectory
+        #endif
+		
         return try NSFileManager.defaultManager().URLForDirectory(
-            .DocumentDirectory,
+            searchPathDirectory,
             inDomain: .UserDomainMask,
             appropriateForURL: nil,
             create: true)
     }
     catch {
-        fatalError("*** Error finding documents directory: \(error)")
+        fatalError("*** Error finding default directory: \(error)")
     }
 }

--- a/Tests/ModelTests.swift
+++ b/Tests/ModelTests.swift
@@ -46,7 +46,7 @@ class ModelTests: XCTestCase {
         // THEN: the model has the correct name, bundle, and type
         XCTAssertEqual(model.name, modelName)
         XCTAssertEqual(model.bundle, modelBundle)
-        XCTAssertEqual(model.storeType, StoreType.SQLite(DocumentsDirectoryURL()))
+        XCTAssertEqual(model.storeType, StoreType.SQLite(DefaultDirectoryURL()))
 
         // THEN: the model returns the correct database filename
         XCTAssertEqual(model.databaseFileName, model.name + ".sqlite")

--- a/Tests/StackResultTests.swift
+++ b/Tests/StackResultTests.swift
@@ -50,7 +50,7 @@ class StackResultTests: TestCase {
         let success2 = CoreDataStackResult.Success(inMemoryStack)
         XCTAssertEqual(success1, success2)
 
-        let model = CoreDataModel(name: modelName, bundle: modelBundle, storeType: .SQLite(DocumentsDirectoryURL()))
+        let model = CoreDataModel(name: modelName, bundle: modelBundle, storeType: .SQLite(DefaultDirectoryURL()))
         let factory = CoreDataStackFactory(model: model)
         let result = factory.createStack()
         let stack = result.stack()!

--- a/Tests/StoreTypeTests.swift
+++ b/Tests/StoreTypeTests.swift
@@ -28,7 +28,7 @@ import JSQCoreDataKit
 class StoreTypeTests: XCTestCase {
 
     func test_StoreType_SQLite() {
-        let url = DocumentsDirectoryURL()
+        let url = DefaultDirectoryURL()
 
         let s = StoreType.SQLite(url)
         XCTAssertEqual(s.type, NSSQLiteStoreType)
@@ -36,7 +36,7 @@ class StoreTypeTests: XCTestCase {
     }
 
     func test_StoreType_Binary() {
-        let url = DocumentsDirectoryURL()
+        let url = DefaultDirectoryURL()
 
         let s = StoreType.Binary(url)
         XCTAssertEqual(s.type, NSBinaryStoreType)
@@ -50,7 +50,7 @@ class StoreTypeTests: XCTestCase {
     }
 
     func test_StoreType_Equality() {
-        let url = DocumentsDirectoryURL()
+        let url = DefaultDirectoryURL()
 
         let sqlite = StoreType.SQLite(url)
         let binary = StoreType.Binary(url)
@@ -62,7 +62,7 @@ class StoreTypeTests: XCTestCase {
     }
 
     func test_StoreType_Equality_SQLite() {
-        let url = DocumentsDirectoryURL()
+        let url = DefaultDirectoryURL()
 
         let sqlite1 = StoreType.SQLite(url)
         let sqlite2 = StoreType.SQLite(url)
@@ -73,7 +73,7 @@ class StoreTypeTests: XCTestCase {
     }
 
     func test_StoreType_Equality_Binary() {
-        let url = DocumentsDirectoryURL()
+        let url = DefaultDirectoryURL()
 
         let binary1 = StoreType.Binary(url)
         let binary2 = StoreType.Binary(url)
@@ -91,7 +91,7 @@ class StoreTypeTests: XCTestCase {
 
     func test_StoreType_Description() {
         print("\(__FUNCTION__)")
-        let url = DocumentsDirectoryURL()
+        let url = DefaultDirectoryURL()
 
         let sqlite = StoreType.SQLite(url)
         print(sqlite)


### PR DESCRIPTION
I refactored `DocumentsDirectoryURL` to `DefaultDirectoryURL` in source and test files. And, updated this method to using `.CachesDirectory` as the search directory path for tvOS. Fix for #61 