### PR TITLE
Issue 60 stack structure

### DIFF
--- a/Source/CoreDataStackFactory.swift
+++ b/Source/CoreDataStackFactory.swift
@@ -92,7 +92,7 @@ public struct CoreDataStackFactory: CustomStringConvertible, Equatable {
 
             dispatch_async(dispatch_get_main_queue()) {
                 let mainContext = self.createContext(.MainQueueConcurrencyType, name: "main")
-                mainContext.parentContext = backgroundContext
+                mainContext.persistentStoreCoordinator = storeCoordinator
 
                 let stack = CoreDataStack(
                     model: self.model,
@@ -128,7 +128,7 @@ public struct CoreDataStackFactory: CustomStringConvertible, Equatable {
         backgroundContext.persistentStoreCoordinator = storeCoordinator
 
         let mainContext = self.createContext(.MainQueueConcurrencyType, name: "main")
-        mainContext.parentContext = backgroundContext
+        mainContext.persistentStoreCoordinator = storeCoordinator
 
         let stack = CoreDataStack(
             model: model,

--- a/Tests/ContextSyncTests.swift
+++ b/Tests/ContextSyncTests.swift
@@ -50,7 +50,6 @@ class ContextSyncTests: TestCase {
 
         // WHEN: we save the main context
         expectationForNotification(NSManagedObjectContextDidSaveNotification, object: inMemoryStack.mainContext, handler: nil)
-        expectationForNotification(NSManagedObjectContextDidSaveNotification, object: inMemoryStack.backgroundContext, handler: nil)
 
         saveContext(inMemoryStack.mainContext) { result in
             XCTAssertTrue(result == .success)
@@ -75,6 +74,17 @@ class ContextSyncTests: TestCase {
         // GIVEN: objects in the background context
         let companies = generateDataInContext(inMemoryStack.backgroundContext, companiesCount: 3, employeesCount: 3)
         let companyNames = companies.map { $0.name }
+
+        // WHEN: we save the background context
+        expectationForNotification(NSManagedObjectContextDidSaveNotification, object: inMemoryStack.backgroundContext, handler: nil)
+
+        saveContext(inMemoryStack.backgroundContext) { result in
+            XCTAssertTrue(result == .success)
+        }
+
+        waitForExpectationsWithTimeout(DefaultTimeout) { (error) in
+            XCTAssertNil(error, "Expectation should not error")
+        }
 
         // WHEN: we fetch the objects from the main context
         let request = FetchRequest<Company>(entity: entity(name: Company.entityName, context: inMemoryStack.mainContext))

--- a/Tests/SaveTests.swift
+++ b/Tests/SaveTests.swift
@@ -54,9 +54,9 @@ class SaveTests: TestCase {
             return true
         }
 
-        var didSaveBackground = false
-        expectationForNotification(NSManagedObjectContextDidSaveNotification, object: stack.backgroundContext) { (notification) -> Bool in
-            didSaveBackground = true
+        var didUpdateBackground = false
+        expectationForNotification(NSManagedObjectContextObjectsDidChangeNotification, object: stack.backgroundContext) { (notification) -> Bool in
+            didUpdateBackground = true
             return true
         }
 
@@ -74,7 +74,7 @@ class SaveTests: TestCase {
         waitForExpectationsWithTimeout(DefaultTimeout, handler: { (error) -> Void in
             XCTAssertNil(error, "Expectation should not error")
             XCTAssertTrue(didSaveMain, "Main context should be saved")
-            XCTAssertTrue(didSaveBackground, "Background context should be saved")
+            XCTAssertTrue(didUpdateBackground, "Background context should be updated")
         })
     }
 
@@ -90,9 +90,9 @@ class SaveTests: TestCase {
             return true
         }
 
-        var didSaveBackground = false
-        expectationForNotification(NSManagedObjectContextDidSaveNotification, object: stack.backgroundContext) { (notification) -> Bool in
-            didSaveBackground = true
+        var didUpdateBackground = false
+        expectationForNotification(NSManagedObjectContextObjectsDidChangeNotification, object: stack.backgroundContext) { (notification) -> Bool in
+            didUpdateBackground = true
             return true
         }
 
@@ -105,7 +105,7 @@ class SaveTests: TestCase {
         waitForExpectationsWithTimeout(DefaultTimeout, handler: { (error) -> Void in
             XCTAssertNil(error, "Expectation should not error")
             XCTAssertTrue(didSaveMain, "Main context should be saved")
-            XCTAssertTrue(didSaveBackground, "Background context should be saved")
+            XCTAssertTrue(didUpdateBackground, "Background context should be updated")
         })
     }
 
@@ -135,9 +135,9 @@ class SaveTests: TestCase {
             return true
         }
 
-        var didSaveBackground = false
-        expectationForNotification(NSManagedObjectContextDidSaveNotification, object: stack.backgroundContext) { (notification) -> Bool in
-            didSaveBackground = true
+        var didUpdateBackground = false
+        expectationForNotification(NSManagedObjectContextObjectsDidChangeNotification, object: stack.backgroundContext) { (notification) -> Bool in
+            didUpdateBackground = true
             return true
         }
 
@@ -155,7 +155,7 @@ class SaveTests: TestCase {
         waitForExpectationsWithTimeout(DefaultTimeout, handler: { (error) -> Void in
             XCTAssertNil(error, "Expectation should not error")
             XCTAssertTrue(didSaveMain, "Main context should be saved")
-            XCTAssertTrue(didSaveBackground, "Background context should be saved")
+            XCTAssertTrue(didUpdateBackground, "Background context should be updated")
         })
     }
 
@@ -178,9 +178,9 @@ class SaveTests: TestCase {
             return true
         }
 
-        var didSaveBackground = false
-        expectationForNotification(NSManagedObjectContextDidSaveNotification, object: stack.backgroundContext) { (notification) -> Bool in
-            didSaveBackground = true
+        var didUpdateBackground = false
+        expectationForNotification(NSManagedObjectContextObjectsDidChangeNotification, object: stack.backgroundContext) { (notification) -> Bool in
+            didUpdateBackground = true
             return true
         }
 
@@ -199,7 +199,43 @@ class SaveTests: TestCase {
             XCTAssertNil(error, "Expectation should not error")
             XCTAssertTrue(didSaveChild, "Child context should be saved")
             XCTAssertTrue(didSaveMain, "Main context should be saved")
+            XCTAssertTrue(didUpdateBackground, "Background context should be updated")
+        })
+    }
+
+    func test_ThatSavingBackgroundContext_SucceedsAndUpdateMainContext() {
+        // GIVEN: a stack and context with changes
+        let stack = self.inMemoryStack
+
+        generateCompaniesInContext(stack.backgroundContext, count: 3)
+
+        var didSaveBackground = false
+        expectationForNotification(NSManagedObjectContextDidSaveNotification, object: stack.backgroundContext) { (notification) -> Bool in
+            didSaveBackground = true
+            return true
+        }
+
+        var didUpdateMain = false
+        expectationForNotification(NSManagedObjectContextObjectsDidChangeNotification, object: stack.mainContext) { (notification) -> Bool in
+            didUpdateMain = true
+            return true
+        }
+
+        let saveExpectation = expectationWithDescription("\(#function)")
+
+        // WHEN: we attempt to save the context asynchronously
+        saveContext(stack.backgroundContext, wait: false) { result in
+
+            // THEN: the save succeeds without an error
+            XCTAssertTrue(result == .success, "Save should not error")
+            saveExpectation.fulfill()
+        }
+
+        // THEN: then the main and background contexts are saved and the completion handler is called
+        waitForExpectationsWithTimeout(DefaultTimeout, handler: { (error) -> Void in
+            XCTAssertNil(error, "Expectation should not error")
             XCTAssertTrue(didSaveBackground, "Background context should be saved")
+            XCTAssertTrue(didUpdateMain, "Main context should be updated")
         })
     }
     

--- a/Tests/StackFactoryTests.swift
+++ b/Tests/StackFactoryTests.swift
@@ -126,7 +126,7 @@ class StackFactoryTests: TestCase {
 
         XCTAssertEqual(stack.mainContext.name, "JSQCoreDataKit.CoreDataStack.context.main")
         XCTAssertEqual(stack.mainContext.concurrencyType, NSManagedObjectContextConcurrencyType.MainQueueConcurrencyType)
-        XCTAssertEqual(stack.mainContext.parentContext, stack.backgroundContext)
+        XCTAssertNil(stack.mainContext.parentContext)
         XCTAssertNotNil(stack.mainContext.persistentStoreCoordinator)
 
         XCTAssertEqual(stack.backgroundContext.name, "JSQCoreDataKit.CoreDataStack.context.background")


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/HowToContribute).

#### This fixes issue #60 

## What's in this pull request?
- change stack structure so that both background and main contexts are connected to the persistent store coordinator
- sync mechanism between contexts now use `mergeChangesFromContextDidSaveNotification(_:)`

## What's not in this pull request?
- child contexts creation with background context as parent.
`childContext` use the main context as parent. This may not be something we want with this new structure (at least not all the time).
- some of the tests may be simplified or changed to reflect the new stack structure and update mechanism.