### PR TITLE
Move `deleteObjects` function to a `NSManagedObjectContext` extension

### DIFF
--- a/Example/ExampleApp/CompanyViewController.swift
+++ b/Example/ExampleApp/CompanyViewController.swift
@@ -131,7 +131,7 @@ class CompanyViewController: UITableViewController, NSFetchedResultsControllerDe
 
             do {
                 let objects = try fetch(request: request, inContext: backgroundChildContext)
-                deleteObjects(objects, inContext: backgroundChildContext)
+                backgroundChildContext.deleteObjects(objects)
                 saveContext(backgroundChildContext)
             } catch {
                 print("Error deleting objects: \(error)")
@@ -177,7 +177,7 @@ class CompanyViewController: UITableViewController, NSFetchedResultsControllerDe
     override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
         if editingStyle == .Delete {
             let obj = frc?.objectAtIndexPath(indexPath) as! Company
-            deleteObjects([obj], inContext: self.stack.mainContext)
+            self.stack.mainContext.deleteObjects([obj])
             saveContext(self.stack.mainContext)
         }
     }

--- a/Example/ExampleApp/EmployeeViewController.swift
+++ b/Example/ExampleApp/EmployeeViewController.swift
@@ -60,7 +60,7 @@ class EmployeeViewController: UITableViewController, NSFetchedResultsControllerD
 
             do {
                 let objects = try fetch(request: request, inContext: backgroundChildContext)
-                deleteObjects(objects, inContext: backgroundChildContext)
+                backgroundChildContext.deleteObjects(objects)
                 saveContext(backgroundChildContext)
             } catch {
                 print("Error deleting objects: \(error)")
@@ -138,7 +138,7 @@ class EmployeeViewController: UITableViewController, NSFetchedResultsControllerD
     override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
         if editingStyle == .Delete {
             let obj = frc?.objectAtIndexPath(indexPath) as! Employee
-            deleteObjects([obj], inContext: self.stack.mainContext)
+            self.stack.mainContext.deleteObjects([obj])
             saveContext(self.stack.mainContext)
         }
     }

--- a/JSQCoreDataKit.xcodeproj/project.pbxproj
+++ b/JSQCoreDataKit.xcodeproj/project.pbxproj
@@ -65,6 +65,10 @@
 		8873E2691C51E10100DFE009 /* StoreTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8873E25A1C51E10100DFE009 /* StoreTypeTests.swift */; };
 		8873E26A1C51E10100DFE009 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8873E25B1C51E10100DFE009 /* TestCase.swift */; };
 		8873E2C11C51E3D400DFE009 /* ExampleModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8873E2C01C51E3B000DFE009 /* ExampleModel.framework */; };
+		FE3D29351CD124140076C97F /* CoreDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3D29341CD124140076C97F /* CoreDataExtensions.swift */; };
+		FE3D29361CD124140076C97F /* CoreDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3D29341CD124140076C97F /* CoreDataExtensions.swift */; };
+		FE3D29371CD124140076C97F /* CoreDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3D29341CD124140076C97F /* CoreDataExtensions.swift */; };
+		FE3D29381CD124140076C97F /* CoreDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3D29341CD124140076C97F /* CoreDataExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -126,6 +130,7 @@
 		8873E2BB1C51E3B000DFE009 /* ExampleModel.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ExampleModel.xcodeproj; path = Example/ExampleModel/ExampleModel.xcodeproj; sourceTree = SOURCE_ROOT; };
 		887403131C0D6A6D00FE0C31 /* JSQCoreDataKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JSQCoreDataKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		88AC4B331C0FD8DA00A04563 /* JSQCoreDataKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JSQCoreDataKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FE3D29341CD124140076C97F /* CoreDataExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -193,6 +198,7 @@
 		8873E21C1C51E09700DFE009 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				FE3D29341CD124140076C97F /* CoreDataExtensions.swift */,
 				8873E21E1C51E09700DFE009 /* CoreDataFunctions.swift */,
 				8873E21F1C51E09700DFE009 /* CoreDataModel.swift */,
 				8873E2211C51E09700DFE009 /* CoreDataStack.swift */,
@@ -478,6 +484,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8873E22C1C51E09700DFE009 /* CoreDataStackFactory.swift in Sources */,
+				FE3D29351CD124140076C97F /* CoreDataExtensions.swift in Sources */,
 				8873E2301C51E09700DFE009 /* StoreType.swift in Sources */,
 				8873E22B1C51E09700DFE009 /* CoreDataStack.swift in Sources */,
 				298F00F71C9C559100AEC77E /* Migrate.swift in Sources */,
@@ -516,6 +523,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FE3D29371CD124140076C97F /* CoreDataExtensions.swift in Sources */,
 				8873E2411C51E0DE00DFE009 /* CoreDataStackFactory.swift in Sources */,
 				8873E2431C51E0DE00DFE009 /* StoreType.swift in Sources */,
 				8873E2401C51E0DE00DFE009 /* CoreDataStack.swift in Sources */,
@@ -532,6 +540,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FE3D29361CD124140076C97F /* CoreDataExtensions.swift in Sources */,
 				8873E2391C51E0DD00DFE009 /* CoreDataStackFactory.swift in Sources */,
 				8873E23B1C51E0DD00DFE009 /* StoreType.swift in Sources */,
 				8873E2381C51E0DD00DFE009 /* CoreDataStack.swift in Sources */,
@@ -548,6 +557,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FE3D29381CD124140076C97F /* CoreDataExtensions.swift in Sources */,
 				8873E2491C51E0DE00DFE009 /* CoreDataStackFactory.swift in Sources */,
 				8873E24B1C51E0DE00DFE009 /* StoreType.swift in Sources */,
 				8873E2481C51E0DE00DFE009 /* CoreDataStack.swift in Sources */,

--- a/Source/CoreDataExtensions.swift
+++ b/Source/CoreDataExtensions.swift
@@ -1,0 +1,40 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://www.jessesquires.com/JSQCoreDataKit
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQCoreDataKit
+//
+//
+//  License
+//  Copyright © 2015 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+import CoreData
+import Foundation
+
+public extension NSManagedObjectContext {
+    /**
+     Deletes the objects from the context.
+     You must save the context after calling this function to remove objects from their persistent store.
+
+     - note: This function is performed synchronously in a block on the context's queue.
+
+     - parameter objects: The managed objects to be deleted.
+     */
+    public func deleteObjects <T: NSManagedObject>(objects: [T]) {
+        guard objects.count != 0 else { return }
+
+        self.performBlockAndWait {
+            for each in objects {
+                self.deleteObject(each)
+            }
+        }
+    }
+}

--- a/Source/CoreDataFunctions.swift
+++ b/Source/CoreDataFunctions.swift
@@ -111,23 +111,3 @@ public func fetch <T: NSManagedObject>(request request: FetchRequest<T>, inConte
 
     return results as! [T]
 }
-
-
-/**
- Deletes the objects from the specified context.
- You must save the context after calling this function to remove objects from their persistent store.
-
- - note: This function is performed synchronously in a block on the context's queue.
-
- - parameter objects: The managed objects to be deleted.
- - parameter context: The context to which the objects belong.
- */
-public func deleteObjects <T: NSManagedObject>(objects: [T], inContext context: NSManagedObjectContext) {
-    guard objects.count != 0 else { return }
-
-    context.performBlockAndWait {
-        for each in objects {
-            context.deleteObject(each)
-        }
-    }
-}

--- a/Tests/DeleteTests.swift
+++ b/Tests/DeleteTests.swift
@@ -39,7 +39,7 @@ class DeleteTests: TestCase {
         XCTAssertEqual(results.count, count)
 
         // WHEN: we delete the objects
-        deleteObjects(objects, inContext: stack.mainContext)
+        stack.mainContext.deleteObjects(objects)
 
         // THEN: the objects are removed from the context
         let resultAfterDelete = try! fetch(request: request, inContext: stack.mainContext)
@@ -72,7 +72,7 @@ class DeleteTests: TestCase {
         XCTAssertEqual(resultForObject.first!, myEmployee, "Fetched object should equal expected model")
 
         // WHEN: we delete a specific object
-        deleteObjects([myEmployee], inContext: stack.mainContext)
+        stack.mainContext.deleteObjects([myEmployee])
 
         // THEN: the specific object is removed from the context
         let resultAfterDelete = try! fetch(request: request, inContext: stack.mainContext)
@@ -93,7 +93,7 @@ class DeleteTests: TestCase {
         let stack = self.inMemoryStack
 
         // WHEN: we delete an empty array of objects
-        deleteObjects([], inContext: stack.mainContext)
+        stack.mainContext.deleteObjects([])
         
         // THEN: the operation is ignored
         XCTAssertFalse(stack.mainContext.hasChanges)


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/HowToContribute).

#### This fixes the `deleteObjects` part of issue #69.

## What's in this pull request?
- `deleteObjects` is now an extension's method on `NSManagedObjectContext`
- extension lives in a dedicated `CoreDataExtensions.swift` file.