### PR TITLE
Put `migrate()` into a `CoreDataModel` extension

### DIFF
--- a/Tests/MigrationTests.swift
+++ b/Tests/MigrationTests.swift
@@ -53,7 +53,7 @@ class MigrationTests: TestCase {
         XCTAssertFalse(model.needsMigration)
 
         // THEN: calling migrate does nothing
-        try! migrate(model)
+        try! model.migrate()
     }
 
     func test_ThatModelMigrates_Successfully() {
@@ -63,7 +63,7 @@ class MigrationTests: TestCase {
 
         // WHEN: CoreDataModel is migrated
         do {
-            try migrate(model)
+            try model.migrate()
         } catch {
             XCTFail("Failed to migrate model: \(error)")
         }


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/HowToContribute).

#### This fixes issue #80

## What's in this pull request?

Move `migrate()` into a `CoreDataModel` extension while keeping the code in `Migrate.swift`.
I did not touch the related `internal` top level functions. I do not know if you want these to be put in the extension as well.