### PR TITLE
Provide the ability for the CoreDataStackFactory user to supply their…

### DIFF
--- a/Tests/StackFactoryTests.swift
+++ b/Tests/StackFactoryTests.swift
@@ -95,6 +95,30 @@ class StackFactoryTests: TestCase {
 
         validateStack(stack!, fromFactory: factory)
     }
+    
+    func test_ThatStackFactory_UsesPersistentStoreCoordinatorFactory_Successfully() {
+        // GIVEN: a core data model
+        let sqliteModel = CoreDataModel(name: modelName, bundle: modelBundle)
+        
+        // GIVEN: a simple PersistentStoreCoordinator factory method
+        let persistentStoreCoordinatorFactory = { (managedObjectModel: NSManagedObjectModel, options: PersistentStoreOptions?) throws -> NSPersistentStoreCoordinator in
+            let storeCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
+            try storeCoordinator.addPersistentStoreWithType(sqliteModel.storeType.type, configuration: nil, URL: sqliteModel.storeURL, options: options)
+            return storeCoordinator
+        }
+        
+        // GIVEN: a factory
+        let factory = CoreDataStackFactory(model: sqliteModel, options: nil, persistentStoreCoordinatorFactory: persistentStoreCoordinatorFactory)
+        
+        // WHEN: we create a stack
+        let result = factory.createStack()
+        let stack = result.stack()
+
+        XCTAssertNotNil(stack)
+        XCTAssertNil(result.error())
+
+        validateStack(stack!, fromFactory: factory)
+    }
 
     func test_StackFactory_Equality() {
         let factory1 = CoreDataStackFactory(model: inMemoryModel)


### PR DESCRIPTION
## Pull request checklist

- [ √ ] All tests pass. Demo project builds and runs.
- [ √ ] I have resolved any merge conflicts.
- [ √ ] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/HowToContribute).

## What's in this pull request?

For a current project, I needed to supply a custom NSPersistentStoreCoordinator subclass so I could support an encrypted backing store.  This pull request adds the ability to supply an optional factory method to the CoreDataStackFactory that allows the user of the factory to do just that.  I included test coverage and all tests pass.