### PR TITLE
Compile for both Swift 2.2 and Swift 2.3

### DIFF
--- a/Source/Migrate.swift
+++ b/Source/Migrate.swift
@@ -79,13 +79,13 @@ extension CoreDataModel {
                                             type: storeType.type,
                                             options: nil,
                                             withMappingModel: step.mapping,
-                                            toDestinationURL: tempURL!,
+                                            toDestinationURL: tempURL ?? NSURL(),
                                             destinationType: storeType.type,
                                             destinationOptions: nil)
 
             // could throw file system errors
             try removeExistingStore()
-            try NSFileManager.defaultManager().moveItemAtURL(tempURL!, toURL: storeURL)
+            try NSFileManager.defaultManager().moveItemAtURL(tempURL ?? NSURL(), toURL: storeURL)
         }
     }
 }


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/HowToContribute).

## What's in this pull request?

By using nil-coalescing operator instead of force-unwrap, it's possible to compile for both Swift 2.2 and Swift 2.3.

It seems like you can completely skip releasing extra major version for Swift 2.3, since you can have a minor one, that works in both 2.2 and 2.3.