### PR TITLE
[travis ci] Fixes iOS 13.2 failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ jobs:
       env: DESTINATION="OS=12.0,name=iPhone X" SDK="$IOS_SDK"
 
     - <<: *test
-      name: iOS 13.2
-      env: DESTINATION="OS=13.2,name=iPhone 11" SDK="$IOS_SDK"
+      name: iOS 13.2.2
+      env: DESTINATION="OS=13.2.2,name=iPhone 11" SDK="$IOS_SDK"
 
     - <<: *test
       name: macOS
@@ -85,8 +85,8 @@ jobs:
       env: DESTINATION="OS=12.0,name=iPhone X" SDK="$IOS_SDK"
 
     - <<: *build-examples
-      name: iOS 13.2
-      env: DESTINATION="OS=13.2,name=iPhone 11" SDK="$IOS_SDK"
+      name: iOS 13.2.2
+      env: DESTINATION="OS=13.2.2,name=iPhone 11" SDK="$IOS_SDK"
 
     - stage: lint
       name: pod lint


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. 
- [x] Demo project builds and runs.
- [x] I have resolved merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines) and [contributing guidelines](https://github.com/jessesquires/HowToContribute).

#### This fixes issue
- Fixes travis-ci build failure.
  - Reason: iOS 13.2 isn't available.

## What's in this pull request?
- Updated iOS destination from 13.2 to 13.2.2. 