### PR TITLE
Update the build settings

### DIFF
--- a/JSQCoreDataKit.xcodeproj/project.pbxproj
+++ b/JSQCoreDataKit.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		882986082006938A008DD41B /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/jessesquires/.github/blob/master/CONTRIBUTING.md)?*

Issue N/A

## Describe your changes

This PR unchecks "Based on dependency analysis" in the 'SwiftLint' build phase to resolve the following Xcode warning:

```
warning build: Run script build phase 'SwiftLint' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.
```