### PR TITLE
Use `Self` to refer to type names

### DIFF
--- a/Example/ExampleModel/ExampleModel/Company.swift
+++ b/Example/ExampleModel/ExampleModel/Company.swift
@@ -53,9 +53,9 @@ public final class Company: NSManagedObject, CoreDataEntityProtocol {
 
     public static func newCompany(_ context: NSManagedObjectContext) -> Company {
         let name = "Company " + String(UUID().uuidString.split { $0 == "-" }.first!)
-        return Company(context: context,
-                       name: name,
-                       dateFounded: Date.distantPast,
-                       profits: NSDecimalNumber(value: Int.random(in: 0...1_000_000)))
+        return Self(context: context,
+                    name: name,
+                    dateFounded: Date.distantPast,
+                    profits: NSDecimalNumber(value: Int.random(in: 0...1_000_000)))
     }
 }

--- a/Example/ExampleModel/ExampleModel/Employee.swift
+++ b/Example/ExampleModel/ExampleModel/Employee.swift
@@ -54,11 +54,11 @@ public final class Employee: NSManagedObject, CoreDataEntityProtocol {
 
     public static func newEmployee(_ context: NSManagedObjectContext, company: Company? = nil) -> Employee {
         let name = "Employee " + String(UUID().uuidString.split { $0 == "-" }.first!)
-        return Employee(context: context,
-                        name: name,
-                        birthDate: Date.distantPast,
-                        salary: NSDecimalNumber(value: Int.random(in: 0...100_000)),
-                        company: company)
+        return Self(context: context,
+                    name: name,
+                    birthDate: Date.distantPast,
+                    salary: NSDecimalNumber(value: Int.random(in: 0...100_000)),
+                    company: company)
     }
 
     public static func fetchRequest(for company: Company) -> NSFetchRequest<Employee> {


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/jessesquires/.github/blob/master/CONTRIBUTING.md)?*

Issue N/A

## Describe your changes

This PR changes to refer to type names using `Self` to resolve the following SwiftLint warning:

```
Prefer Self in Static References Violation: Use `Self` to refer to the surrounding type name (prefer_self_in_static_references)
```

Ref: https://realm.github.io/SwiftLint/prefer_self_in_static_references.html